### PR TITLE
Fix 404 error on refresh of routes other than /

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
When you refresh a page like https://rrtt-weather.netlify.app/Munich you get a Netlify 404 error.  
This PR should fix it.